### PR TITLE
feat: [FC-0063] Argument processing update

### DIFF
--- a/cc2olx_plugin/templates/cc2olx/build/cc2olx/Dockerfile
+++ b/cc2olx_plugin/templates/cc2olx/build/cc2olx/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8.20-alpine3.20
 
-RUN apk fix &&  \
-    apk --no-cache --update add git git-lfs gpg less openssh patch perl && \
+RUN apk fix && \
+    apk --no-cache --update add gcc musl-dev python3-dev git git-lfs gpg less openssh patch perl && \
     git lfs install && \
     pip install --no-cache-dir git+https://github.com/openedx/cc2olx@{{ CC2OLX_BRANCH }}#egg=cc2olx
 


### PR DESCRIPTION
## Description  
### `-i`/`--inputs` argument behavior is changed to sync it with cc2olx changes
Previously, `-i`/`--inputs` argument of `cc2olx` converter could take several arguments the next way:
```bash
cc2olx -i <IMSCC_FILE_1> <IMSCC_FILE_2>
```
`cc2olx` converter has been updated and now it can be achieved by running
```bash
cc2olx -i <IMSCC_FILE_1> -i <IMSCC_FILE_2>
```
It allowed us to simplify the argument processing, so the corresponding changes are made in CLI command processing. 

### `--logs_dir` argument support is added
If the `--logs_dir` argument that has been introduced in the converter recently is provided to the Tutor command, it ensures that the provided path ancestors exist in the user filesystem.

## Depenencies
- [feat: [FC-0063] Fault tolerance improving](https://github.com/raccoongang/cc2olx/pull/10)

## Supporting information
FC-0063

## Deadline
"None"